### PR TITLE
fix #95: spurious "cpp should include its header file"

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -4815,7 +4815,19 @@ def CheckIncludeLine(filename, clean_lines, linenum, include_state, error):
               'Do not include .' + extension + ' files from other packages')
         return
 
-    if not _THIRD_PARTY_HEADERS_PATTERN.match(include):
+    # We DO want to include a 3rd party looking header if it matches the
+    # filename. Otherwise we get an erroneous error "...should include its
+    # header" error later.
+    third_src_header = False
+    for ext in GetHeaderExtensions():
+      basefilename = filename[0:len(filename) - len(fileinfo.Extension())]
+      headerfile = basefilename + '.' + ext
+      headername = FileInfo(headerfile).RepositoryName()
+      if headername in include or include in headername:
+        third_src_header = True
+        break
+
+    if third_src_header or not _THIRD_PARTY_HEADERS_PATTERN.match(include):
       include_state.include_list[-1].append((include, linenum))
 
       # We want to ensure that headers appear in the right order:

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -4671,6 +4671,74 @@ class CpplintTest(CpplintTestBase):
     # Restore previous CWD.
     os.chdir(cur_dir)
 
+  def testIncludeItsHeader(self):
+    temp_directory = tempfile.mkdtemp()
+    cur_dir = os.getcwd()
+    try:
+      test_directory = os.path.join(temp_directory, "test")
+      os.makedirs(test_directory)
+      file_path = os.path.join(test_directory, 'foo.h')
+      open(file_path, 'a').close()
+      file_path = os.path.join(test_directory, 'Bar.h')
+      open(file_path, 'a').close()
+
+      os.chdir(temp_directory)
+
+      error_collector = ErrorCollector(self.assertTrue)
+      cpplint.ProcessFileData(
+        'test/foo.cc', 'cc',
+        [''],
+        error_collector)
+      expected = "{dir}/{fn}.cc should include its header file {dir}/{fn}.h  [build/include] [5]".format(
+          fn="foo",
+          dir=test_directory)
+      self.assertEqual(
+        1,
+        error_collector.Results().count(expected))
+
+      error_collector = ErrorCollector(self.assertTrue)
+      cpplint.ProcessFileData(
+        'test/foo.cc', 'cc',
+        [r'#include "test/foo.h"',
+         ''
+         ],
+        error_collector)
+      self.assertEqual(
+        0,
+        error_collector.Results().count(expected))
+
+      # This should continue to work
+      error_collector = ErrorCollector(self.assertTrue)
+      cpplint.ProcessFileData(
+        'test/Bar.cc', 'cc',
+        [r'#include "test/Bar.h"',
+         ''
+         ],
+        error_collector)
+      expected = "{dir}/{fn}.cc should include its header file {dir}/{fn}.h  [build/include] [5]".format(
+          fn="Bar",
+          dir=test_directory)
+      self.assertEqual(
+        0,
+        error_collector.Results().count(expected))
+
+      # Since Bar.cc & Bar.h look 3rd party-ish, it should be ok without the include dir
+      error_collector = ErrorCollector(self.assertTrue)
+      cpplint.ProcessFileData(
+        'test/Bar.cc', 'cc',
+        [r'#include "Bar.h"',
+         ''
+         ],
+        error_collector)
+      self.assertEqual(
+        0,
+        error_collector.Results().count(expected))
+
+    finally:
+      # Restore previous CWD.
+      os.chdir(cur_dir)
+      shutil.rmtree(temp_directory)
+
   def testPathSplitToList(self):
     self.assertEquals([''],
                       cpplint.PathSplitToList(os.path.join('')))


### PR DESCRIPTION
fix #95: spurious "cpp should include its header file"