### PR TITLE
Fixed search for repository root directory

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -1356,6 +1356,7 @@ class FileInfo(object):
             os.path.exists(os.path.join(current_dir, ".hg")) or
             os.path.exists(os.path.join(current_dir, ".svn"))):
           root_dir = current_dir
+          break
         current_dir = os.path.dirname(current_dir)
 
       if (os.path.exists(os.path.join(root_dir, ".git")) or


### PR DESCRIPTION
In the situation, where one git/svn/hg repository is located inside the
directory tree of another, the search incorrectly selects the outer one
instead of the inner one.